### PR TITLE
Removed eval from for macro

### DIFF
--- a/src/util/util.lisp
+++ b/src/util/util.lisp
@@ -2,7 +2,7 @@
 
 (defmacro for (expr &body body)
   (let* ((vars (reverse (cdr (reverse `,expr))))
-         (generator (eval (car (last `,expr))))
+         (generator (car (last `,expr)))
          (iter (gensym "iter")))
     `(let ((,iter ,generator))
        (labels ((f (,@vars)


### PR DESCRIPTION
Not sure if there was a good reason for having the `for` macro call `eval` on the generator function call form, but I removed it and the resulting system passes all the tests and avoids causing bugs with other code.